### PR TITLE
added feature to specify a custom directory in raw

### DIFF
--- a/pykitti/raw.py
+++ b/pykitti/raw.py
@@ -18,7 +18,8 @@ class raw:
 
     def __init__(self, base_path, date, drive, **kwargs):
         """Set the path and pre-load calibration data and timestamps."""
-        self.drive = date + '_drive_' + drive + '_sync'
+        self.dataset = kwargs.get('dataset', 'sync')
+        self.drive = date + '_drive_' + drive + '_' + self.dataset
         self.calib_path = os.path.join(base_path, date)
         self.data_path = os.path.join(base_path, date, self.drive)
         self.frames = kwargs.get('frames', None)


### PR DESCRIPTION
I have added a feature to specify a custom directory (keeping the default as sync) while using the class raw.

I am using a custom directory to prepare a synced but unrectified subset of the raw dataset to create a ROS bag with my fork of [kitti2bag](https://github.com/ar13pit/kitti2bag)

This pull request shouldn't break the current code.