### PR TITLE
No 'FileNotFoundError' on Python2.x

### DIFF
--- a/pykitti/odometry.py
+++ b/pykitti/odometry.py
@@ -12,6 +12,12 @@ import pykitti.utils as utils
 __author__ = "Lee Clement"
 __email__ = "lee.clement@robotics.utias.utoronto.ca"
 
+##Since Python2.x has no 'FileNotFoundError' exception, define it
+##Python3.x should do fine
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
 
 class odometry:
     """Load and parse odometry benchmark data into a usable format."""


### PR DESCRIPTION
Since Python2.x does not have `FileNotFoundError` then `_load_poses()` fails. Just added a way around it.