### PR TITLE
Allow int values as input to drive and sequence params, remove an unused cv2 dependency

### DIFF
--- a/pykitti/odometry.py
+++ b/pykitti/odometry.py
@@ -24,8 +24,8 @@ class odometry:
 
     def __init__(self, base_path, sequence, **kwargs):
         """Set the path."""
-        self.sequence = sequence
-        self.sequence_path = os.path.join(base_path, 'sequences', sequence)
+        self.sequence = str(sequence).zfill(2)
+        self.sequence_path = os.path.join(base_path, 'sequences', self.sequence)
         self.pose_path = os.path.join(base_path, 'poses')
         self.frames = kwargs.get('frames', None)
 

--- a/pykitti/raw.py
+++ b/pykitti/raw.py
@@ -19,6 +19,7 @@ class raw:
     def __init__(self, base_path, date, drive, **kwargs):
         """Set the path and pre-load calibration data and timestamps."""
         self.dataset = kwargs.get('dataset', 'sync')
+        drive = str(drive).zfill(4)
         self.drive = date + '_drive_' + drive + '_' + self.dataset
         self.calib_path = os.path.join(base_path, date)
         self.data_path = os.path.join(base_path, date, self.drive)

--- a/pykitti/tracking.py
+++ b/pykitti/tracking.py
@@ -26,7 +26,7 @@ class tracking:
     def __init__(self, base_path, sequence, **kwargs):
         """Set the path."""
         self.base_path = base_path
-        self.sequence = sequence
+        self.sequence = str(sequence).zfill(4)
         self.frames = kwargs.get('frames', None)
 
         # Default image file extension is 'png'

--- a/pykitti/tracking.py
+++ b/pykitti/tracking.py
@@ -9,7 +9,6 @@ import pandas as pd
 import numpy as np
 
 import pykitti.utils as utils
-import cv2
 
 try:
     xrange


### PR DESCRIPTION
This makes initializing the classes a bit more convenient.
The `cv2` dependency is quite heavy-weight and entirely unused right now.

By the way, would it be possible to create a new minor release of pykitti that incorporates the fix from #39, please? I'm using pykitti via [kitti2bag](https://github.com/tomas789/kitti2bag) and ROS1 is stuck with Python 2 for at least another year, unfortunately.