### PR TITLE
Fixed error with Tracking calibration loading.

### DIFF
--- a/pykitti/tracking.py
+++ b/pykitti/tracking.py
@@ -129,7 +129,8 @@ class tracking:
         data = {}
 
         # Load the calibration file
-        calib_filepath = os.path.join(self.sequence_path + '.txt', 'calib.txt')
+        # calib_filepath = os.path.join(self.sequence_path + '.txt', 'calib.txt')
+        calib_filepath = os.path.join(self.base_path, 'calib', self.sequence + '.txt')
         filedata = utils.read_calib_file(calib_filepath)
 
         # Create 3x4 projection matrices

--- a/pykitti/tracking.py
+++ b/pykitti/tracking.py
@@ -153,7 +153,7 @@ class tracking:
         T3[0, 3] = P_rect_30[0, 3] / P_rect_30[0, 0]
 
         # Compute the velodyne to rectified camera coordinate transforms
-        data['T_cam0_velo'] = np.reshape(filedata['Tr'], (3, 4))
+        data['T_cam0_velo'] = np.reshape(filedata['Tr_velo_cam'], (3, 4))
         data['T_cam0_velo'] = np.vstack([data['T_cam0_velo'], [0, 0, 0, 1]])
         data['T_cam1_velo'] = T1.dot(data['T_cam0_velo'])
         data['T_cam2_velo'] = T2.dot(data['T_cam0_velo'])

--- a/pykitti/utils.py
+++ b/pykitti/utils.py
@@ -71,7 +71,10 @@ def read_calib_file(filepath):
 
     with open(filepath, 'r') as f:
         for line in f.readlines():
-            key, value = line.split(':', 1)
+            try:
+                key, value = line.split(':', 1)
+            except ValueError:
+                key, value = line.split(' ', 1)
             # The only non-float values in these files are dates, which
             # we don't care about anyway
             try:


### PR DESCRIPTION
Fixed error with the calibration file read that was generating a ValueError when trying to read from the tracking calibration file. The file is formatted differently from the from the Raw and Odometry calibration files, using spaces to separate the transform matrices from the values instead of a colon. Also updated the code in the tracking class to accommodate the differences in the calibration file. The _load_calibration file had a call to "self.sequence_path" that did not exist, updated the call with the correct formatting for the calibration file path.